### PR TITLE
GHA improve workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -31,16 +31,16 @@ jobs:
 
       - name: Run tests
         run: npm test
-        
-      - uses: actions/checkout@v2
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
 
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      # - uses: actions/checkout@v2
+      # - name: Install Vercel CLI
+      #   run: npm install --global vercel@latest
 
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      # - name: Pull Vercel Environment Information
+      #   run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      # - name: Build Project Artifacts
+      #   run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      # - name: Deploy Project Artifacts to Vercel
+      #   run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build_job:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
- set timeout for 15 mins instead of 360 mins (default) to prevent run out free GHA time
- bump node version to 18 (same like on vercel)
- comment fragment with vercel push